### PR TITLE
new upstream for fix CVE-2018-10933

### DIFF
--- a/.abf.yml
+++ b/.abf.yml
@@ -3,3 +3,4 @@ removed_sources:
   libssh-0.7.0.tar.xz: e39d77ef00f17e721aa6bf251621776f262d5575
 sources:
   libssh-0.7.3.tar.xz: 9de2a8fde51aa7b7855008fafd5bf47ebb01289f
+  libssh-0.7.6.tar.xz: 8e5f23a861f84fa214ca1da0e3f98b839ff7c051

--- a/libssh.spec
+++ b/libssh.spec
@@ -6,13 +6,13 @@
 Summary:	C library to authenticate in a simple manner to one or more SSH servers
 Name:		libssh
 Epoch:		1
-Version:	0.7.3
+Version:	0.7.6
 Release:	1
 Group:		System/Libraries
 License:	LGPLv2.1+
 Url:		http://www.libssh.org
 # svn checkout svn://svn.berlios.de/libssh/trunk libssh
-Source0:	https://red.libssh.org/attachments/download/41/%{name}-%{version}.tar.xz
+Source0:	https://www.libssh.org/files/%(echo %{version} |cut -d. -f1-2)/%{name}-%{version}.tar.xz
 Patch0:		libssh-0.6.3-clang.patch
 BuildRequires:	cmake
 BuildRequires:	doxygen


### PR DESCRIPTION
0.7.6 fix security issue CVE-2018-10933. BUG 2378 https://issues.openmandriva.org/show_bug.cgi?id=2378